### PR TITLE
Fix KeyError: xCenter in sketchgraphs/pipeline/graph_model/quantization.py

### DIFF
--- a/sketchgraphs/pipeline/graph_model/quantization.py
+++ b/sketchgraphs/pipeline/graph_model/quantization.py
@@ -208,6 +208,9 @@ _entity_label_to_target_type_dict = {
     datalib.EntityType.Point: TargetType.NodePoint
 }
 
+_entity_label_from_target_type_dict = {v: k for k, v in _entity_label_to_target_type_dict.items()}
+
+
 def _op_string_label_to_target_type(label):
     return _entity_label_to_target_type_dict.get(label, TargetType.NodeGeneric)
 
@@ -310,13 +313,6 @@ class EntityFeatureMapping:
             offset = 2
         else:
             offset = 1
-
-        _entity_label_from_target_type_dict = {
-            TargetType.NodeArc: datalib.EntityType.Arc,
-            TargetType.NodeCircle: datalib.EntityType.Circle,
-            TargetType.NodeLine: datalib.EntityType.Line,
-            TargetType.NodePoint: datalib.EntityType.Point
-        }
 
         target_entity = _entity_label_from_target_type_dict[target]
 

--- a/sketchgraphs/pipeline/graph_model/quantization.py
+++ b/sketchgraphs/pipeline/graph_model/quantization.py
@@ -311,7 +311,16 @@ class EntityFeatureMapping:
         else:
             offset = 1
 
-        for i, (param_name, centers) in enumerate(self._bin_centers.get(target, {}).items()):
+        _entity_label_from_target_type_dict = {
+            TargetType.NodeArc: datalib.EntityType.Arc,
+            TargetType.NodeCircle: datalib.EntityType.Circle,
+            TargetType.NodeLine: datalib.EntityType.Line,
+            TargetType.NodePoint: datalib.EntityType.Point
+        }
+
+        target_entity = _entity_label_from_target_type_dict[target]
+
+        for i, (param_name, centers) in enumerate(self._bin_centers.get(target_entity, {}).items()):
             features[param_name] = centers[index[i + offset]]
 
         return features


### PR DESCRIPTION
# Symptom

As we discussed in #12 .

I was trying to run the `sketchgraphs_models/graph/sample.py` to extract some generated examples from the model.  I did this using
```
python -m sketchgraphs_models.graph.sample --output_path /path/to/output/sampled_data.pkl --model_state path/to/output/0219/time_104135/model_state_50.pt
```

I hit an error

```
Exception has occurred: KeyError
'xCenter'
  File "xxxx/sketchgraphs/pipeline/graph_model/quantization.py", line 258, in _numerical_features
    feature[i + offset] = int(np.searchsorted(edges, params[param_name]))
 
````

# Problem

Digging into what is going on I see the dictionary `params` is generated by the following code

[sketchgraphs/pipeline/graph_model/quantization.py#L314-L315](https://github.com/PrincetonLIPS/SketchGraphs/blob/master/sketchgraphs/pipeline/graph_model/quantization.py#L314-L315)
```
        for i, (param_name, centers) in enumerate(self._bin_centers.get(target, {}).items()):
            features[param_name] = centers[index[i + offset]]
```

Here `target`has type `<TargetType.NodeCircle: 8>` but inside the `self._bin_centers` dictionary we have `<EntityType.Circle: 2>`.   Hence the `features` dictionary isn't built up correctly.

# Solution

As we discussed in #12 .

I added the line

```
_entity_label_from_target_type_dict = {v: k for k, v in _entity_label_to_target_type_dict.items()}
```
and then use this look up in `features_from_index()`

# Verification

I tested that this fix still works.  Everything runs fine after the solution given to me in #15 
